### PR TITLE
Output should be sent to NUL

### DIFF
--- a/src/Barryvdh/Queue/AsyncQueue.php
+++ b/src/Barryvdh/Queue/AsyncQueue.php
@@ -55,7 +55,7 @@ class AsyncQueue extends Queue implements QueueInterface {
         $string = 'php artisan queue:async %s --env=%s';
 
         if (substr(php_uname(), 0, 7) == "Windows"){  
-            $string = 'start /B ' . $string; 
+            $string = 'start /B ' . $string . ' > NUL'; 
         } 
         else { 
             $string .= ' > /dev/null 2>&1 &';


### PR DESCRIPTION
Quite important, as the output might otherwise be written to log files. Laravel recursion errors and log files make an interesting combination. :)
