### PR TITLE
Check app version before passing [command] to Process

### DIFF
--- a/src/AsyncQueue.php
+++ b/src/AsyncQueue.php
@@ -134,7 +134,7 @@ class AsyncQueue extends DatabaseQueue
         $command = $this->getCommand($id);
         $cwd = base_path();
 
-        $process = new Process([$command], $cwd);
+        $process = new Process((int)app()->version() > 6 ? [$command] : $command, $cwd);
         $process->run();
     }
 


### PR DESCRIPTION
Symfony Process Does not accept array before Laravel 7 So The app version should be checked